### PR TITLE
LUN-2965: Fix css for poster image, <a> buttons and checkboxes.

### DIFF
--- a/cms_blogger/widgets.py
+++ b/cms_blogger/widgets.py
@@ -10,14 +10,8 @@ class ToggleWidget(forms.widgets.CheckboxInput):
 
     def render(self, name, value, attrs={}):
         attrs.update({'class': 'ace ace-switch ace-switch-4 btn-empty'})
-        widget_html = super(ToggleWidget, self).render(
+        return super(ToggleWidget, self).render(
             name, value, attrs=attrs)
-        is_disabled = (self.attrs.get('disabled', False) or
-                       attrs.get('disabled', False))
-        active = 'false' if is_disabled else 'true'
-        output = ("<label class='pull-left'>"
-                  "%s<span class='lbl'></span></label>" % widget_html)
-        return mark_safe(output)
 
 
 class TagItWidget(forms.widgets.TextInput):

--- a/cms_blogger/widgets.py
+++ b/cms_blogger/widgets.py
@@ -49,8 +49,7 @@ class TagItWidget(forms.widgets.TextInput):
         return mark_safe(output)
 
 
-class ButtonWidget(forms.widgets.CheckboxInput):
-    # make it a CheckboxInput in order to not show the ':' after the label
+class ButtonWidget(forms.widgets.Widget):
 
     class Media:
         css = {
@@ -75,9 +74,9 @@ class ButtonWidget(forms.widgets.CheckboxInput):
         "'name', '_continue').val('Save')"
         ").submit();")
 
-    def __init__(self, attrs=None, check_test=None, link_url='',
+    def __init__(self, attrs=None, link_url='',
                  text=None, submit=False, on_click=''):
-        super(ButtonWidget, self).__init__(attrs, check_test)
+        super(ButtonWidget, self).__init__(attrs)
         self.text = text
         self.link_url = link_url or "#"
         self.submit = submit
@@ -151,7 +150,7 @@ class DateTimeWidget(forms.widgets.TextInput):
         return value_as_date.astimezone(tz.tzutc())
 
 
-class PosterImage(forms.widgets.CheckboxInput):
+class PosterImage(forms.widgets.Widget):
 
     class Media:
         js = (static('filer/js/fileuploader.js'),)
@@ -169,6 +168,16 @@ class PosterImage(forms.widgets.CheckboxInput):
             }
         )
 
+    def value_from_datadict(self, data, files, name):
+        """
+        The PosterImage Widget does not use the normal django form
+        validation/input field naming and conventions.
+        The image is directly uploaded before the form is saved.
+
+        In the past PosterImage inherited CheckboxInput which made this
+        function always return False and only hid the workaround.
+        """
+        return False
 
 class SpinnerWidget(forms.widgets.TextInput):
 


### PR DESCRIPTION
We relied on CheckboxInput for workarounds so ButtonWidget (no longer the case) and PosterImage worked.
Now we style normal checkbox input differently and we rely on it beeing an actual checkbox, this is why the workarounds should now be made more explicit.